### PR TITLE
Adding RECAPTCHA_DISABLE to disable recaptcha

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -41,6 +41,8 @@ You have already learned these configuration at :ref:`recaptcha`.
 This table is only designed for a convience.
 
 ======================= ==============================================
+RECAPTCHA_DISABLE       Disable recaptcha widgets.
+                        Default is False
 RECAPTCHA_USE_SSL       Enable/disable recaptcha through ssl.
                         Default is False.
 RECAPTCHA_PUBLIC_KEY    **required** A public key.

--- a/docs/form.rst
+++ b/docs/form.rst
@@ -147,6 +147,11 @@ Example of RECAPTCHA_PARAMETERS, and RECAPTCHA_DATA_ATTRS::
 For testing your application, if ``app.testing`` is ``True``, recaptcha
 field will always be valid for you convenience.
 
+In development environment or when you are offline you can disable all
+recaptcha fields::
+
+    RECAPTCHA_DISABLE = True
+
 And it can be easily setup in the templates:
 
 .. sourcecode:: html+jinja

--- a/flask_wtf/recaptcha/validators.py
+++ b/flask_wtf/recaptcha/validators.py
@@ -31,7 +31,7 @@ class Recaptcha(object):
         self.message = message
 
     def __call__(self, form, field):
-        if current_app.testing:
+        if current_app.testing or current_app.config.get('RECAPTCHA_DISABLE', False):
             return True
 
         if request.json:

--- a/flask_wtf/recaptcha/widgets.py
+++ b/flask_wtf/recaptcha/widgets.py
@@ -35,7 +35,7 @@ class RecaptchaWidget(object):
         """Returns the recaptcha input HTML."""
 
         if current_app.config.get('RECAPTCHA_DISABLE', False):
-	    return '<!-- disable recaptcha -->'
+            return '<!-- disable recaptcha -->'
         try:
             public_key = current_app.config['RECAPTCHA_PUBLIC_KEY']
         except KeyError:

--- a/flask_wtf/recaptcha/widgets.py
+++ b/flask_wtf/recaptcha/widgets.py
@@ -34,6 +34,8 @@ class RecaptchaWidget(object):
     def __call__(self, field, error=None, **kwargs):
         """Returns the recaptcha input HTML."""
 
+        if current_app.config.get('RECAPTCHA_DISABLE', False):
+	    return '<!-- disable recaptcha -->'
         try:
             public_key = current_app.config['RECAPTCHA_PUBLIC_KEY']
         except KeyError:

--- a/flask_wtf/recaptcha/widgets.py
+++ b/flask_wtf/recaptcha/widgets.py
@@ -35,7 +35,7 @@ class RecaptchaWidget(object):
         """Returns the recaptcha input HTML."""
 
         if current_app.config.get('RECAPTCHA_DISABLE', False):
-            return '<!-- disable recaptcha -->'
+            return Markup(u'<!-- recaptcha disabled -->')
         try:
             public_key = current_app.config['RECAPTCHA_PUBLIC_KEY']
         except KeyError:


### PR DESCRIPTION
This pull request allows you to use forms, without commenting on the recaptcha field when you are offline.
