### PR TITLE
Add support to customize `RECAPTCHA_VERIFY_SERVER` and `RECAPTCHA_SCRIPT`

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -27,16 +27,20 @@ Configuration
 Recaptcha
 ---------
 
-========================= ==============================================
-``RECAPTCHA_PUBLIC_KEY``  **required** A public key.
-``RECAPTCHA_PRIVATE_KEY`` **required** A private key.
-                          https://www.google.com/recaptcha/admin
-``RECAPTCHA_PARAMETERS``  **optional** A dict of configuration options.
-``RECAPTCHA_HTML``        **optional** Override default HTML template
-                          for Recaptcha.
-``RECAPTCHA_DATA_ATTRS``  **optional** A dict of ``data-`` attrs to use
-                          for Recaptcha div
-========================= ==============================================
+============================ ==============================================
+``RECAPTCHA_PUBLIC_KEY``     **required** A public key.
+``RECAPTCHA_PRIVATE_KEY``    **required** A private key.
+                             https://www.google.com/recaptcha/admin
+``RECAPTCHA_PARAMETERS``     **optional** A dict of configuration options.
+``RECAPTCHA_HTML``           **optional** Override default HTML template
+                             for Recaptcha.
+``RECAPTCHA_VERIFY_SERVER``  **optional** Override default verify server
+                             address for Recaptcha.
+``RECAPTCHA_SCRIPT``         **optional** Override default recaptcha script
+                             address for Recaptcha.
+``RECAPTCHA_DATA_ATTRS``     **optional** A dict of ``data-`` attrs to use
+                             for Recaptcha div
+============================ ==============================================
 
 Logging
 -------

--- a/examples/recaptcha/app.py
+++ b/examples/recaptcha/app.py
@@ -12,6 +12,9 @@ SECRET_KEY = 'secret'
 
 RECAPTCHA_PUBLIC_KEY = '6LeYIbsSAAAAACRPIllxA7wvXjIE411PfdB2gt2J'
 RECAPTCHA_PRIVATE_KEY = '6LeYIbsSAAAAAJezaIq3Ft_hSTo0YtyeFG-JgRtu'
+# If the default server is blocked, you can switch to the mirror server
+# RECAPTCHA_VERIFY_SERVER = 'https://recaptcha.net/recaptcha/api/siteverify'
+# RECAPTCHA_SCRIPT = 'https://recaptcha.net/recaptcha/api.js'
 
 app = Flask(__name__)
 app.config.from_object(__name__)

--- a/flask_wtf/recaptcha/validators.py
+++ b/flask_wtf/recaptcha/validators.py
@@ -12,7 +12,7 @@ from wtforms import ValidationError
 
 from .._compat import to_bytes, to_unicode
 
-RECAPTCHA_VERIFY_SERVER = 'https://www.google.com/recaptcha/api/siteverify'
+DEFAULT_RECAPTCHA_VERIFY_SERVER = 'https://www.google.com/recaptcha/api/siteverify'
 RECAPTCHA_ERROR_CODES = {
     'missing-input-secret': 'The secret parameter is missing.',
     'invalid-input-secret': 'The secret parameter is invalid or malformed.',
@@ -62,7 +62,9 @@ class Recaptcha(object):
             'response':   response
         })
 
-        http_response = http.urlopen(RECAPTCHA_VERIFY_SERVER, to_bytes(data))
+        recaptcha_verify_server = current_app.config.get(
+            'RECAPTCHA_VERIFY_SERVER', DEFAULT_RECAPTCHA_VERIFY_SERVER)
+        http_response = http.urlopen(recaptcha_verify_server, to_bytes(data))
 
         if http_response.code != 200:
             return False

--- a/flask_wtf/recaptcha/widgets.py
+++ b/flask_wtf/recaptcha/widgets.py
@@ -5,7 +5,7 @@ from werkzeug import url_encode
 
 JSONEncoder = json.JSONEncoder
 
-RECAPTCHA_SCRIPT = u'https://www.google.com/recaptcha/api.js'
+DEFAULT_RECAPTCHA_SCRIPT = u'https://www.google.com/recaptcha/api.js'
 RECAPTCHA_TEMPLATE = u'''
 <script src='%s' async defer></script>
 <div class="g-recaptcha" %s></div>
@@ -21,7 +21,8 @@ class RecaptchaWidget(object):
         if html:
             return Markup(html)
         params = current_app.config.get('RECAPTCHA_PARAMETERS')
-        script = RECAPTCHA_SCRIPT
+        script = current_app.config.get('RECAPTCHA_SCRIPT',
+                                        DEFAULT_RECAPTCHA_SCRIPT)
         if params:
             script += u'?' + url_encode(params)
 


### PR DESCRIPTION
The default recaptcha server is blocked in China, so I hope `flask-wtf` can support a custom server.

Thank you.