### PR TITLE
docs: quickstart: iterate errors, not object itself

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -71,7 +71,7 @@ would look like this:
 
     {% if form.name.errors %}
         <ul class="errors">
-        {% for error in form.name %}
+        {% for error in form.name.errors %}
             <li>{{ error }}</li>
         {% endfor %}
         </ul>


### PR DESCRIPTION
This PR replaces `form.name` with `form.name.errors` in `docs/quickstart.rst` as suggested by me in #451.

- fixes #451
