### PR TITLE
Disable CSRF check for requests without cookies

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -5,7 +5,7 @@ Version 0.16.0
 --------------
 
 Unreleased
-
+-   Add ``WTF_CSRF_CHECK_WITHOUT_COOKIE`` setting to avoid calling CSRF check on requests without cookies
 
 Version 0.15.1
 --------------

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1,32 +1,35 @@
 Configuration
 =============
 
-========================== =====================================================
-``WTF_CSRF_ENABLED``       Set to ``False`` to disable all CSRF protection.
-                           Default is ``True``.
-``WTF_CSRF_CHECK_DEFAULT`` When using the CSRF protection extension, this
-                           controls whether every view is protected by default.
-                           Default is ``True``.
-``WTF_CSRF_SECRET_KEY``    Random data for generating secure tokens. If this is
-                           not set then ``SECRET_KEY`` is used.
-``WTF_CSRF_METHODS``       HTTP methods to protect from CSRF. Default is
-                           ``{'POST', 'PUT', 'PATCH', 'DELETE'}``.
-``WTF_CSRF_FIELD_NAME``    Name of the form field and session key that holds the
-                           CSRF token. Default is ``csrf_token``.
-``WTF_CSRF_HEADERS``       HTTP headers to search for CSRF token when it is not
-                           provided in the form. Default is
-                           ``['X-CSRFToken', 'X-CSRF-Token']``.
-``WTF_CSRF_TIME_LIMIT``    Max age in seconds for CSRF tokens. Default is
-                           ``3600``. If set to ``None``, the CSRF token is valid
-                           for the life of the session.
-``WTF_CSRF_SSL_STRICT``    Whether to enforce the same origin policy by checking
-                           that the referrer matches the host. Only applies to
-                           HTTPS requests. Default is ``True``.
-``WTF_I18N_ENABLED``       Set to ``False`` to disable Flask-Babel I18N support.
-                           Also set to ``False`` if you want to use WTForms's
-                           built-in messages directly, see more info `here`_.
-                           Default is ``True``.
-========================== =====================================================
+=================================== =====================================================
+``WTF_CSRF_ENABLED``                Set to ``False`` to disable all CSRF protection.
+                                    Default is ``True``.
+``WTF_CSRF_CHECK_DEFAULT``          When using the CSRF protection extension, this
+                                    controls whether every view is protected by default.
+                                    Default is ``True``.
+``WTF_CSRF_SECRET_KEY``             Random data for generating secure tokens. If this is
+                                    not set then ``SECRET_KEY`` is used.
+``WTF_CSRF_METHODS``                HTTP methods to protect from CSRF. Default is
+                                    ``{'POST', 'PUT', 'PATCH', 'DELETE'}``.
+``WTF_CSRF_FIELD_NAME``             Name of the form field and session key that holds the
+                                    CSRF token. Default is ``csrf_token``.
+``WTF_CSRF_HEADERS``                HTTP headers to search for CSRF token when it is not
+                                    provided in the form. Default is
+                                    ``['X-CSRFToken', 'X-CSRF-Token']``.
+``WTF_CSRF_TIME_LIMIT``             Max age in seconds for CSRF tokens. Default is
+                                    ``3600``. If set to ``None``, the CSRF token is valid
+                                    for the life of the session.
+``WTF_CSRF_SSL_STRICT``             Whether to enforce the same origin policy by checking
+                                    that the referrer matches the host. Only applies to
+                                    HTTPS requests. Default is ``True``.
+``WTF_I18N_ENABLED``                Set to ``False`` to disable Flask-Babel I18N support.
+                                    Also set to ``False`` if you want to use WTForms's
+                                    built-in messages directly, see more info `here`_.
+                                    Default is ``True``.
+``WTF_CSRF_CHECK_WITHOUT_COOKIE``   Set to ``False`` to disable CSRF check for requests
+                                    without cookies.
+                                    Default is ``True``.
+=================================== =====================================================
 
 .. _here: https://wtforms.readthedocs.io/en/stable/i18n.html#using-the-built-in-translations-provider
 

--- a/src/flask_wtf/csrf.py
+++ b/src/flask_wtf/csrf.py
@@ -203,6 +203,7 @@ class CSRFProtect:
         app.config.setdefault("WTF_CSRF_HEADERS", ["X-CSRFToken", "X-CSRF-Token"])
         app.config.setdefault("WTF_CSRF_TIME_LIMIT", 3600)
         app.config.setdefault("WTF_CSRF_SSL_STRICT", True)
+        app.config.setdefault("WTF_CSRF_CHECK_WITHOUT_COOKIE", True)
 
         app.jinja_env.globals["csrf_token"] = generate_csrf
         app.context_processor(lambda: {"csrf_token": generate_csrf})
@@ -222,6 +223,9 @@ class CSRFProtect:
                 return
 
             if request.blueprint in self._exempt_blueprints:
+                return
+            
+            if not app.config["WTF_CSRF_CHECK_WITHOUT_COOKIE"] and not request.cookies:
                 return
 
             view = app.view_functions.get(request.endpoint)

--- a/src/flask_wtf/csrf.py
+++ b/src/flask_wtf/csrf.py
@@ -224,7 +224,7 @@ class CSRFProtect:
 
             if request.blueprint in self._exempt_blueprints:
                 return
-            
+
             if not app.config["WTF_CSRF_CHECK_WITHOUT_COOKIE"] and not request.cookies:
                 return
 


### PR DESCRIPTION
I don't think that CSRF validation makes sense when request has no cookies at all. But it also makes life harder when you develop API that shared the same Flask application as the regular users.

I thought that it is a good idea to add such functionality. All comments are welcome!

- fixes #453

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `docs/changes.rst` summarizing the change and linking to the issue. Add `.. versionchanged::` entries in any relevant code docs.
