### PR TITLE
Include CONTRIBUTING.rst in source distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include tox.ini
 include requirements/*.txt
+include CONTRIBUTING.rst
 graft docs
 prune docs/_build
 graft examples


### PR DESCRIPTION
Hi,
This fixes the following error:
```
Flask-WTF-1.0.0/docs/contributing.rst:1: WARNING: Problems with "include" directive path:
InputError: [Errno 2] No such file or directory: 'CONTRIBUTING.rst'.
```

Since this affects the doc build, I didn't include the checklist.

