### PR TITLE
Multiple file support

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -21,6 +21,8 @@ Forms and Fields
 
 .. autoclass:: FileField
 
+.. autoclass:: MultipleFileField
+
 .. autoclass:: FileAllowed
 
 .. autoclass:: FileRequired

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -5,6 +5,7 @@ Version 1.0.1
 --------------
 
 Released 2022-01-18
+
 - Add `flask-wtf.file.MultipleFileField` and ``FileRequired``,
     ``FileAllowed``, ``FileSize`` validators support for this field
     :pr: `499` :issue:`337` :issue:`393`

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,14 @@
 Changes
 =======
 
+Version 1.0.1
+--------------
+
+Released 2022-01-18
+- Add `flask-wtf.file.MultipleFileField` and ``FileRequired``,
+    ``FileAllowed``, ``FileSize`` validators support for this field
+    :pr: `499` :issue:`337` :issue:`393`
+
 Version 1.0.0
 --------------
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -8,7 +8,7 @@ Released ...
 
 - Add `flask-wtf.file.MultipleFileField` and ``FileRequired``,
     ``FileAllowed``, ``FileSize`` validators support for this field
-    :pr: `499` :issue:`337` :issue:`393`
+    :pr:`499` :issue:`337` :issue:`393`
 
 Version 1.0.0
 --------------

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,7 +4,7 @@ Changes
 Version 1.0.1
 --------------
 
-Released 2022-01-18
+Released ...
 
 - Add `flask-wtf.file.MultipleFileField` and ``FileRequired``,
     ``FileAllowed``, ``FileSize`` validators support for this field

--- a/docs/form.rst
+++ b/docs/form.rst
@@ -30,7 +30,7 @@ File Uploads
 
 .. currentmodule:: flask_wtf.file
 
-The :class:`FileField` provided by Flask-WTF differs from the WTForms-provided
+The :class:`FileField` and :class:`MultipleFileField` provided by Flask-WTF differs from the WTForms-provided
 field. It will check that the file is a non-empty instance of
 :class:`~werkzeug.datastructures.FileStorage`, otherwise ``data`` will be
 ``None``. ::
@@ -82,7 +82,7 @@ Validation
 
 Flask-WTF supports validating file uploads with
 :class:`FileRequired` and :class:`FileAllowed`. They can be used with both
-Flask-WTF's and WTForms's ``FileField`` classes.
+Flask-WTF's and WTForms's ``FileField``, ``MultipleFileField`` classes.
 
 :class:`FileAllowed` works well with Flask-Uploads. ::
 

--- a/docs/form.rst
+++ b/docs/form.rst
@@ -82,7 +82,8 @@ Validation
 
 Flask-WTF supports validating file uploads with
 :class:`FileRequired` and :class:`FileAllowed`. They can be used with both
-Flask-WTF's and WTForms's ``FileField``, ``MultipleFileField`` classes.
+Flask-WTF's and WTForms's ``FileField`` classes. For the ``MultipleFileField``
+only Fask-WTF's implementation is supported.
 
 :class:`FileAllowed` works well with Flask-Uploads. ::
 

--- a/src/flask_wtf/file.py
+++ b/src/flask_wtf/file.py
@@ -13,7 +13,7 @@ class FileField(_FileField):
 
     def process_formdata(self, valuelist):
         valuelist = (x for x in valuelist if isinstance(x, FileStorage) and x)
-        data = list(valuelist) or None
+        data = next(valuelist, None)
 
         if data is not None:
             self.data = data

--- a/src/flask_wtf/file.py
+++ b/src/flask_wtf/file.py
@@ -13,7 +13,7 @@ class FileField(_FileField):
 
     def process_formdata(self, valuelist):
         valuelist = (x for x in valuelist if isinstance(x, FileStorage) and x)
-        data = next(valuelist, None)
+        data = list(valuelist) or None
 
         if data is not None:
             self.data = data

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -1,5 +1,6 @@
 import pytest
 from werkzeug.datastructures import FileStorage
+from werkzeug.datastructures import ImmutableMultiDict
 from werkzeug.datastructures import MultiDict
 from wtforms import FileField as BaseFileField
 
@@ -27,6 +28,27 @@ def test_process_formdata(form):
     assert form(MultiDict((("file", FileStorage()),))).file.data is None
     assert (
         form(MultiDict((("file", FileStorage(filename="real")),))).file.data is not None
+    )
+
+
+def test_multiple_process_formdata(form):
+    assert (
+        form(
+            ImmutableMultiDict([("files", FileStorage()), ("files", FileStorage())])
+        ).files.data
+        is None
+    )
+
+    assert (
+        form(
+            ImmutableMultiDict(
+                [
+                    ("files", FileStorage(filename="a.jpg")),
+                    ("files", FileStorage(filename="b.jpg")),
+                ]
+            )
+        ).files.data
+        is not None
     )
 
 


### PR DESCRIPTION
`flask-wtf.file.MultipleFileField` and `flask-wtf.file.FileRequired` , `flask-wtf.file.FileAllowed`, `flask-wtf.file.FileSize` support for this field.

- fixes #393
- fixes #337 
