### PR TITLE
Fix Babel Example

### DIFF
--- a/examples/babel/app.py
+++ b/examples/babel/app.py
@@ -3,14 +3,14 @@ from flask import render_template
 from flask import request
 from flask_babel import Babel
 from flask_babel import lazy_gettext as _
-from wtforms import TextField
+from wtforms import StringField
 from wtforms.validators import DataRequired
 
 from flask_wtf import FlaskForm
 
 
 class BabelForm(FlaskForm):
-    name = TextField(_("Name"), validators=[DataRequired()])
+    name = StringField(_("Name"), validators=[DataRequired()])
 
 
 DEBUG = True


### PR DESCRIPTION
`examples/babel/app.py` still imports `TextField` from `wtforms` which has been removed. This PR changes it to `StringField`.

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `docs/changes.rst` summarizing the change and linking to the issue. Add `.. versionchanged::` entries in any relevant code docs.
