### PR TITLE
Fix failing test with Flask 2.2

### DIFF
--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -109,8 +109,6 @@ def test_set_default_message_language(app, client):
         assert not form.validate_on_submit()
         assert "This field is required." in form.name.errors
 
-    client.post("/default", data={"name": "  "})
-
     @app.route("/es", methods=["POST"])
     def es():
         app.config["WTF_I18N_ENABLED"] = False
@@ -128,4 +126,5 @@ def test_set_default_message_language(app, client):
         assert not form.validate_on_submit()
         assert "Este campo es obligatorio." in form.name.errors
 
+    client.post("/default", data={"name": "  "})
     client.post("/es", data={"name": "  "})


### PR DESCRIPTION
Fixes:
* #531 
* https://github.com/NixOS/nixpkgs/pull/190680

Compiling flask-wtf with the current version of flask v2.2.2 breaks the test suite.
The faulty test is `test_set_default_message_language`.

Looks like it is caused by a change in Flask 2.2:

* https://github.com/pallets/flask/pull/4577

A resolution is to move the `client.post` code in the test after the controller code.

Works & tested with Flask 2.1 & 2.2.

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `docs/changes.rst` summarizing the change and linking to the issue. Add `.. versionchanged::` entries in any relevant code docs.
