### PR TITLE
Fixed unit tests for Flask-Babel 3

### DIFF
--- a/examples/babel/app.py
+++ b/examples/babel/app.py
@@ -17,14 +17,7 @@ DEBUG = True
 SECRET_KEY = "secret"
 WTF_I18N_ENABLED = True
 
-app = Flask(__name__)
-app.config.from_object(__name__)
 
-# config babel
-babel = Babel(app)
-
-
-@babel.localeselector
 def get_locale():
     """how to get the locale is defined by you.
 
@@ -37,6 +30,13 @@ def get_locale():
     # this is a demo case, we use url to get locale
     code = request.args.get("lang", "en")
     return code
+
+
+app = Flask(__name__)
+app.config.from_object(__name__)
+
+# config babel
+babel = Babel(app, locale_selector=get_locale)
 
 
 @app.route("/", methods=("GET", "POST"))

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -32,11 +32,10 @@ def test_i18n(app, client):
     except ImportError:
         pytest.skip("Flask-Babel must be installed.")
 
-    babel = Babel(app)
-
-    @babel.localeselector
     def get_locale():
         return request.accept_languages.best_match(["en", "zh"], "en")
+
+    Babel(app, locale_selector=get_locale)
 
     @app.route("/", methods=["POST"])
     def index():


### PR DESCRIPTION
Flask-Babel 3.0.0 has been released yesterday. The [CHANGELOG](https://github.com/python-babel/flask-babel/blob/master/CHANGELOG) indicates that:

> - Babel.locale_selector and Babel.timezone_selector no longer exist. They must be provided
  either when the Babel() object is created or when init_app() is called. This is to support
  having a single Babel object for multiple Flask apps ([#107](https://github.com/python-babel/flask-babel/issues/107)) as well as to simplify settings
  and multi-threaded state.

Those decorators were not used except in unit tests and examples. This PR fixes the unit tests and the CI with flask-babel 3.