### PR TITLE
Add `MultipleFileField` and support validating multiple files

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,14 @@
 Changes
 =======
 
+Version 1.1.3
+-------------
+
+Unreleased
+
+-   Add field ``MultipleFileField``. ``FileRequired``, ``FileAllowed``, ``FileSize``
+    now can be used to validate multiple files :pr:`556` :issue:`338`
+
 Version 1.1.2
 -------------
 

--- a/docs/form.rst
+++ b/docs/form.rst
@@ -56,6 +56,34 @@ field. It will check that the file is a non-empty instance of
 
         return render_template('upload.html', form=form)
 
+
+Similarly, you can use the :class:`MultipleFileField` provided by Flask-WTF
+to handle multiple files. It will check that the files is a list of non-empty instance of
+:class:`~werkzeug.datastructures.FileStorage`, otherwise ``data`` will be
+``None``. ::
+
+    from flask_wtf import FlaskForm
+    from flask_wtf.file import MultipleFileField, FileRequired
+    from werkzeug.utils import secure_filename
+
+    class PhotoForm(FlaskForm):
+        photos = MultipleFileField(validators=[FileRequired()])
+
+    @app.route('/upload', methods=['GET', 'POST'])
+    def upload():
+        form = PhotoForm()
+
+        if form.validate_on_submit():
+            for f in form.photo.data:  # form.photo.data return a list of FileStorage object
+                filename = secure_filename(f.filename)
+                f.save(os.path.join(
+                    app.instance_path, 'photos', filename
+                ))
+            return redirect(url_for('index'))
+
+        return render_template('upload.html', form=form)
+
+
 Remember to set the ``enctype`` of the HTML form to
 ``multipart/form-data``, otherwise ``request.files`` will be empty.
 
@@ -81,8 +109,9 @@ Validation
 ~~~~~~~~~~
 
 Flask-WTF supports validating file uploads with
-:class:`FileRequired` and :class:`FileAllowed`. They can be used with both
-Flask-WTF's and WTForms's ``FileField`` classes.
+:class:`FileRequired`, :class:`FileAllowed`, and :class:`FileSize`. They
+can be used with both Flask-WTF's and WTForms's ``FileField`` and
+``MultipleFileField`` classes.
 
 :class:`FileAllowed` works well with Flask-Uploads. ::
 

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -1,13 +1,17 @@
 import pytest
 from werkzeug.datastructures import FileStorage
+from werkzeug.datastructures import ImmutableMultiDict
 from werkzeug.datastructures import MultiDict
 from wtforms import FileField as BaseFileField
+from wtforms import MultipleFileField as BaseMultipleFileField
+from wtforms.validators import Length
 
 from flask_wtf import FlaskForm
 from flask_wtf.file import FileAllowed
 from flask_wtf.file import FileField
 from flask_wtf.file import FileRequired
 from flask_wtf.file import FileSize
+from flask_wtf.file import MultipleFileField
 
 
 @pytest.fixture
@@ -17,6 +21,7 @@ def form(req_ctx):
             csrf = False
 
         file = FileField()
+        files = MultipleFileField()
 
     return UploadForm
 
@@ -126,3 +131,142 @@ def test_validate_base_field(req_ctx):
     assert not F().validate()
     assert not F(f=FileStorage()).validate()
     assert F(f=FileStorage(filename="real")).validate()
+    assert F(f=FileStorage(filename="real")).validate()
+
+
+def test_process_formdata_for_files(form):
+    assert (
+        form(
+            ImmutableMultiDict([("files", FileStorage()), ("files", FileStorage())])
+        ).files.data
+        is None
+    )
+    assert (
+        form(
+            ImmutableMultiDict(
+                [
+                    ("files", FileStorage(filename="a.jpg")),
+                    ("files", FileStorage(filename="b.jpg")),
+                ]
+            )
+        ).files.data
+        is not None
+    )
+
+
+def test_files_required(form):
+    form.files.kwargs["validators"] = [FileRequired()]
+
+    f = form()
+    assert not f.validate()
+    assert f.files.errors[0] == "This field is required."
+
+    f = form(files="not a file")
+    assert not f.validate()
+    assert f.files.errors[0] == "This field is required."
+
+    f = form(files=[FileStorage()])
+    assert not f.validate()
+
+    f = form(files=[FileStorage(filename="real")])
+    assert f.validate()
+
+
+def test_files_allowed(form):
+    form.files.kwargs["validators"] = [FileAllowed(("txt",))]
+
+    f = form()
+    assert f.validate()
+
+    f = form(
+        files=[FileStorage(filename="test.txt"), FileStorage(filename="test2.txt")]
+    )
+    assert f.validate()
+
+    f = form(files=[FileStorage(filename="test.txt"), FileStorage(filename="test.png")])
+    assert not f.validate()
+    assert f.files.errors[0] == "File does not have an approved extension: txt"
+
+
+def test_files_allowed_uploadset(app, form):
+    pytest.importorskip("flask_uploads")
+    from flask_uploads import UploadSet, configure_uploads
+
+    app.config["UPLOADS_DEFAULT_DEST"] = "uploads"
+    txt = UploadSet("txt", extensions=("txt",))
+    configure_uploads(app, (txt,))
+    form.files.kwargs["validators"] = [FileAllowed(txt)]
+
+    f = form()
+    assert f.validate()
+
+    f = form(
+        files=[FileStorage(filename="test.txt"), FileStorage(filename="test2.txt")]
+    )
+    assert f.validate()
+
+    f = form(files=[FileStorage(filename="test.txt"), FileStorage(filename="test.png")])
+    assert not f.validate()
+    assert f.files.errors[0] == "File does not have an approved extension."
+
+
+def test_validate_base_multiple_field(req_ctx):
+    class F(FlaskForm):
+        class Meta:
+            csrf = False
+
+        f = BaseMultipleFileField(validators=[FileRequired()])
+
+    assert not F().validate()
+    assert not F(f=[FileStorage()]).validate()
+    assert F(f=[FileStorage(filename="real")]).validate()
+
+
+def test_file_size_small_files_pass_validation(form, tmp_path):
+    form.files.kwargs["validators"] = [FileSize(max_size=100)]
+    path = tmp_path / "test_file_smaller_than_max.txt"
+    path.write_bytes(b"\0")
+
+    with path.open("rb") as file:
+        f = form(files=[FileStorage(file)])
+        assert f.validate()
+
+
+@pytest.mark.parametrize(
+    "min_size, max_size, invalid_file_size", [(1, 100, 0), (0, 100, 101)]
+)
+def test_file_size_invalid_file_sizes_fails_validation(
+    form, min_size, max_size, invalid_file_size, tmp_path
+):
+    form.files.kwargs["validators"] = [FileSize(min_size=min_size, max_size=max_size)]
+    path = tmp_path / "test_file_invalid_size.txt"
+    path.write_bytes(b"\0" * invalid_file_size)
+
+    with path.open("rb") as file:
+        f = form(files=[FileStorage(file)])
+        assert not f.validate()
+        assert f.files.errors[
+            0
+        ] == "File must be between {min_size} and {max_size} bytes.".format(
+            min_size=min_size, max_size=max_size
+        )
+
+
+def test_files_length(form, min_num=2, max_num=3):
+    form.files.kwargs["validators"] = [Length(min_num, max_num)]
+
+    f = form(files=[FileStorage("1")])
+    assert not f.validate()
+    assert f.files.errors[
+        0
+    ] == "Field must be between {min_num} and {max_num} characters long.".format(
+        min_num=min_num, max_num=max_num
+    )
+
+    f = form(
+        files=[
+            FileStorage(filename="1"),
+            FileStorage(filename="2"),
+        ]
+    )
+    assert f.validate()


### PR DESCRIPTION
Continue #338

- Add the `MultipleFileField` field.
- Update `FileRequired`, `FileAllowed`, and `FileSize` to make them work with multiple files.
- Add tests for using Length with the files field.


<!--
If you have not contributed to the project before, open a ticket
describing the issue or feature the PR will address to allow discussion
first.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

fixes #337
fixes #393

<!--
Ensure each step for contributing is complete by adding an "x" to each
box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `docs/changes.rst` summarizing the change and linking to the issue. Add `.. versionchanged::` entries in any relevant code docs.
