### PR TITLE
Flask 2.3.0 compatibility

### DIFF
--- a/src/flask_wtf/recaptcha/widgets.py
+++ b/src/flask_wtf/recaptcha/widgets.py
@@ -1,5 +1,5 @@
 from flask import current_app
-from flask import Markup
+from markupsafe import Markup
 from werkzeug.urls import url_encode
 
 RECAPTCHA_SCRIPT_DEFAULT = "https://www.google.com/recaptcha/api.js"


### PR DESCRIPTION
As per #561 and https://flask.palletsprojects.com/en/2.3.x/changes/#version-2-3-0 importing Markup from Flask is deprecated. Import directly from `markupsafe` instead.

- fixes #561 