### PR TITLE
Fix Flask 2.3 deprecations

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,14 @@
 Changes
 =======
 
+Version 1.1.2
+-------------
+
+Unreleased
+
+-   Fixed Flask 2.3 deprecations of ``werkzeug.urls.url_encode`` and
+    ``flask.Markup`` `:pr:`565` :issue:`561`
+
 Version 1.1.1
 -------------
 

--- a/src/flask_wtf/recaptcha/validators.py
+++ b/src/flask_wtf/recaptcha/validators.py
@@ -1,9 +1,9 @@
 import json
 from urllib import request as http
+from urllib.parse import urlencode
 
 from flask import current_app
 from flask import request
-from werkzeug.urls import url_encode
 from wtforms import ValidationError
 
 RECAPTCHA_VERIFY_SERVER_DEFAULT = "https://www.google.com/recaptcha/api/siteverify"
@@ -54,7 +54,7 @@ class Recaptcha:
         if not verify_server:
             verify_server = RECAPTCHA_VERIFY_SERVER_DEFAULT
 
-        data = url_encode(
+        data = urlencode(
             {"secret": private_key, "remoteip": remote_addr, "response": response}
         )
 

--- a/src/flask_wtf/recaptcha/widgets.py
+++ b/src/flask_wtf/recaptcha/widgets.py
@@ -1,6 +1,7 @@
+from urllib.parse import urlencode
+
 from flask import current_app
 from markupsafe import Markup
-from werkzeug.urls import url_encode
 
 RECAPTCHA_SCRIPT_DEFAULT = "https://www.google.com/recaptcha/api.js"
 RECAPTCHA_DIV_CLASS_DEFAULT = "g-recaptcha"
@@ -22,7 +23,7 @@ class RecaptchaWidget:
         if not script:
             script = RECAPTCHA_SCRIPT_DEFAULT
         if params:
-            script += "?" + url_encode(params)
+            script += "?" + urlencode(params)
         attrs = current_app.config.get("RECAPTCHA_DATA_ATTRS", {})
         attrs["sitekey"] = public_key
         snippet = " ".join(f'data-{k}="{attrs[k]}"' for k in attrs)  # noqa: B028, B907

--- a/src/flask_wtf/recaptcha/widgets.py
+++ b/src/flask_wtf/recaptcha/widgets.py
@@ -1,5 +1,5 @@
 from flask import current_app
-from flask import Markup
+from markupsafe import Markup
 from werkzeug.urls import url_encode
 
 RECAPTCHA_SCRIPT_DEFAULT = "https://www.google.com/recaptcha/api.js"

--- a/tests/test_recaptcha.py
+++ b/tests/test_recaptcha.py
@@ -80,7 +80,6 @@ def test_render_custom_args(app):
     app.config["RECAPTCHA_DATA_ATTRS"] = {"red": "blue"}
     f = RecaptchaForm()
     render = f.recaptcha()
-    # new versions of url_encode allow more characters
     assert "?key=(value)" in render or "?key=%28value%29" in render
     assert 'data-red="blue"' in render
 


### PR DESCRIPTION
This fixes all deprecation warnings (`url_encode` and importing `Markup`) introduced with Flask 2.3 and continues #562.

I added a changelog entry as requested by the PR template, I hope version `1.1.2` is fine as the new unreleased version?

- fixes #561
- supersedes #562

<!--
Ensure each step for contributing is complete by adding an "x" to each
box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change. (tests pass with https://github.com/python-babel/flask-babel/pull/230 and should also pass here once this is merged and released)
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `docs/changes.rst` summarizing the change and linking to the issue. Add `.. versionchanged::` entries in any relevant code docs.
