### PR TITLE
chore: test against flask-reuploaded instead of flask-uploads

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist =
 deps =
     -r requirements/tests.txt
     Flask-Babel
-    Flask-Uploads
+    flask-reuploaded
 commands = pytest -v --tb=short --basetemp={envtmpdir} {posargs}
 
 [testenv:py-no-babel]


### PR DESCRIPTION
flask-uploads had no release since 2016, and with the release of werkzeug 1.0 some imports were broken. They were fixed but never released. https://github.com/maxcountryman/flask-uploads/pull/28. Apparently this is not going to change until someone implements tag based release for the project. https://github.com/maxcountryman/flask-uploads/issues/39

flask-reuploaded is a drop-in replacement for flask-uploads, and is actively maintained
https://github.com/jugmac00/flask-reuploaded

This only concerns tests, some of which were skipped due to the buggy imports.