### PR TITLE
nested blueprints can be CSRF exempted

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -10,6 +10,7 @@ Unreleased
     ``flask.Markup`` :pr:`565` :issue:`561`
 -   Stop support for python 3.7 :pr:`574`
 -   Use `pyproject.toml` instead of `setup.cfg` :pr:`576`
+-   Fixed nested blueprint CSRF exemption :pr:`572`
 
 Version 1.1.1
 -------------

--- a/src/flask_wtf/csrf.py
+++ b/src/flask_wtf/csrf.py
@@ -217,7 +217,7 @@ class CSRFProtect:
             if not request.endpoint:
                 return
 
-            if request.blueprint in self._exempt_blueprints:
+            if app.blueprints.get(request.blueprint) in self._exempt_blueprints:
                 return
 
             view = app.view_functions.get(request.endpoint)
@@ -292,7 +292,7 @@ class CSRFProtect:
         """
 
         if isinstance(view, Blueprint):
-            self._exempt_blueprints.add(view.name)
+            self._exempt_blueprints.add(view)
             return view
 
         if isinstance(view, str):

--- a/tests/test_csrf_extension.py
+++ b/tests/test_csrf_extension.py
@@ -154,6 +154,22 @@ def test_exempt_blueprint(app, csrf, client):
     assert response.status_code == 200
 
 
+def test_exempt_nested_blueprint(app, csrf, client):
+    bp1 = Blueprint("exempt1", __name__, url_prefix="/")
+    bp2 = Blueprint("exempt2", __name__, url_prefix="/exempt")
+    csrf.exempt(bp2)
+
+    @bp2.route("/", methods=["POST"])
+    def index():
+        pass
+
+    bp1.register_blueprint(bp2)
+    app.register_blueprint(bp1)
+
+    response = client.post("/exempt/")
+    assert response.status_code == 200
+
+
 def test_error_handler(app, client):
     @app.errorhandler(CSRFError)
     def handle_csrf_error(e):


### PR DESCRIPTION
This is done by storing the blueprint objects instead of their names.
fixes #486 