### PR TITLE
 fix: file validators were editing the file fields content

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,14 @@
 Changes
 =======
 
+Version 1.2.1
+-------------
+
+Unreleased
+
+- Fix a bug introduced with :pr:`556` where file validators were editing
+  the file fields content. :pr:`578`
+
 Version 1.2.0
 -------------
 

--- a/src/flask_wtf/file.py
+++ b/src/flask_wtf/file.py
@@ -47,10 +47,9 @@ class FileRequired(DataRequired):
     """
 
     def __call__(self, form, field):
-        if not isinstance(field.data, list):
-            field.data = [field.data]
+        field_data = [field.data] if not isinstance(field.data, list) else field.data
         if not (
-            all(isinstance(x, FileStorage) and x for x in field.data) and field.data
+            all(isinstance(x, FileStorage) and x for x in field_data) and field_data
         ):
             raise StopValidation(
                 self.message or field.gettext("This field is required.")
@@ -76,14 +75,13 @@ class FileAllowed:
         self.message = message
 
     def __call__(self, form, field):
-        if not isinstance(field.data, list):
-            field.data = [field.data]
+        field_data = [field.data] if not isinstance(field.data, list) else field.data
         if not (
-            all(isinstance(x, FileStorage) and x for x in field.data) and field.data
+            all(isinstance(x, FileStorage) and x for x in field_data) and field_data
         ):
             return
 
-        filenames = [f.filename.lower() for f in field.data]
+        filenames = [f.filename.lower() for f in field_data]
 
         for filename in filenames:
             if isinstance(self.upload_set, abc.Iterable):
@@ -97,7 +95,7 @@ class FileAllowed:
                     ).format(extensions=", ".join(self.upload_set))
                 )
 
-            if not self.upload_set.file_allowed(field.data, filename):
+            if not self.upload_set.file_allowed(field_data, filename):
                 raise StopValidation(
                     self.message
                     or field.gettext("File does not have an approved extension.")
@@ -124,16 +122,14 @@ class FileSize:
         self.message = message
 
     def __call__(self, form, field):
-        if not isinstance(field.data, list):
-            field.data = [field.data]
+        field_data = [field.data] if not isinstance(field.data, list) else field.data
         if not (
-            all(isinstance(x, FileStorage) and x for x in field.data) and field.data
+            all(isinstance(x, FileStorage) and x for x in field_data) and field_data
         ):
             return
 
-        for f in field.data:
+        for f in field_data:
             file_size = len(f.read())
-            print(f, file_size, self.max_size, self.min_size)
             f.seek(0)  # reset cursor position to beginning of file
 
             if (file_size < self.min_size) or (file_size > self.max_size):


### PR DESCRIPTION
When I was playing with the last flask-wtf I noticed that the file validators were editing the `field.data` since #556, leading to incompatibilities: on simple `FileField` my code was expecting a simple `FileStorage` and not a list of `FileStorage`. However the `if not isinstance(field.data, list): field.data = [field.data]` lines was setting a list even for simple `FileField`

@greyli what do you think?